### PR TITLE
chore(bot): add smart contracts functions schedule and exectute

### DIFF
--- a/packages/bot/src/services/subgraph/types.ts
+++ b/packages/bot/src/services/subgraph/types.ts
@@ -25,7 +25,7 @@ export type Action = {
   data: string
 }
 
-type Payload = {
+export type Payload = {
   nonce: string
   executionTime: Timestamp
   submitter: Address


### PR DESCRIPTION
this PR implements the functions `schedule` and `execute` of the `GovernQueue.sol` contract. This functions will be called by the bot using web3 library when a tally from a DR arrives from Witnet